### PR TITLE
Fast verification

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -460,6 +460,7 @@ class CANGui():
             self.default_status_label.config(fg='green',text='UP')
             self.up_down_button.config(fg="red", text="DOWN")
             self.backend_module()
+            self.initial_interface_state()
             self.debugging(" Status is UP", 2)
         else:
             self.module_sender.set_can_status(False)

--- a/GUI.py
+++ b/GUI.py
@@ -382,6 +382,7 @@ class CANGui():
                 else:
                     self.error_listbox.insert(END,"Error: CAN is DOWN")
                     self.error_listbox.itemconfig(END, {'fg': 'red'})
+                    self.loop_active = False
     
 
     def default_module_settings(self):


### PR DESCRIPTION
- In random loop section, when START button is pressed, CAN interface verify if STATUS is UP
if not, an error should appear in the error list.
- When STATUS is set to UP, default interface will be set